### PR TITLE
chore: use go.work to enable VS code intellisense in example scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ _test
 
 .env
 
+.vscode
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/go.work
+++ b/go.work
@@ -1,0 +1,3 @@
+go 1.19
+
+use ./example

--- a/go.work
+++ b/go.work
@@ -1,3 +1,5 @@
 go 1.19
 
+use ./
+
 use ./example


### PR DESCRIPTION
Not sure if this is the best way to enable Intellisense generally but it works for me for VSCode: https://github.com/golang/tools/blob/master/gopls/doc/workspace.md#go-workspaces-go-118 

@TheUnderScorer Can you have a look when you get a chance? Thank you!