### PR TITLE
feat: improve `ApiError`

### DIFF
--- a/.changeset/chilled-games-remain.md
+++ b/.changeset/chilled-games-remain.md
@@ -1,0 +1,5 @@
+---
+"fingerprint-pro-server-api-go-sdk": major
+---
+
+Provide error message from received response rather than status code text in `ApiError.Error()`

--- a/.changeset/healthy-socks-camp.md
+++ b/.changeset/healthy-socks-camp.md
@@ -1,0 +1,5 @@
+---
+"fingerprint-pro-server-api-go-sdk": major
+---
+
+Always throw `sdk.Error` from all Fingerprint API methods

--- a/.changeset/tiny-rockets-roll.md
+++ b/.changeset/tiny-rockets-roll.md
@@ -1,0 +1,5 @@
+---
+"fingerprint-pro-server-api-go-sdk": minor
+---
+
+Provide ErrorCode in `Code()` method in `ApiError`

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ func main() {
 		if errors.As(err, &tooManyRequestsError) {
 			log.Fatalf("Too many requests, retry after %d seconds", tooManyRequestsError.RetryAfter())
 		} else {
+			// You can also use err.Model() and err.Body() to get more details about the error
+			log.Printf("Error %s: %v", err.Code(), err)
 			log.Fatal(err)
 		}
 	}
@@ -84,12 +86,13 @@ func main() {
 
 	event, httpRes, err := client.FingerprintApi.GetEvent(auth, requestId)
 	if err != nil {
+		// You can also use err.Model() and err.Body() to get more details about the error
+		log.Printf("Error %s: %v", err.Code(), err)
 		log.Fatal(err)
-    }
+        }
 
 	if event.Products.Identification != nil {
 		fmt.Printf("Got response with Identification: %v", event.Products.Identification)
-
 	}
 }
 ```

--- a/example/deleteVisit.go
+++ b/example/deleteVisit.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7/sdk"
 	"log"
@@ -39,6 +40,12 @@ func main() {
 	fmt.Printf("%+v\n", httpRes)
 
 	if err != nil {
+		var apiError sdk.ApiError
+
+		if errors.As(err, &apiError) {
+			log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
+		}
+
 		log.Fatal(err)
 	}
 

--- a/example/deleteVisit.go
+++ b/example/deleteVisit.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7/sdk"
 	"log"
@@ -40,13 +39,7 @@ func main() {
 	fmt.Printf("%+v\n", httpRes)
 
 	if err != nil {
-		var apiError sdk.ApiError
-
-		if errors.As(err, &apiError) {
-			log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
-		}
-
-		log.Fatal(err)
+		log.Fatalf("Error: %s, %s", err.Code(), err.Error())
 	}
 
 }

--- a/example/getEvent.go
+++ b/example/getEvent.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -40,13 +39,7 @@ func main() {
 	fmt.Printf("%+v\n", httpRes)
 
 	if err != nil {
-		var apiError sdk.ApiError
-
-		if errors.As(err, &apiError) {
-			log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
-		}
-
-		log.Fatal(err)
+		log.Fatalf("Error: %s, %s", err.Code(), err.Error())
 	}
 
 	if response.Products.Botd != nil {

--- a/example/getEvent.go
+++ b/example/getEvent.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -39,6 +40,12 @@ func main() {
 	fmt.Printf("%+v\n", httpRes)
 
 	if err != nil {
+		var apiError sdk.ApiError
+
+		if errors.As(err, &apiError) {
+			log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
+		}
+
 		log.Fatal(err)
 	}
 

--- a/example/getRelatedVisitors.go
+++ b/example/getRelatedVisitors.go
@@ -44,19 +44,13 @@ func main() {
 		if errors.As(err, &tooManyRequestsError) {
 			log.Printf("Too many requests, retry after %d seconds", tooManyRequestsError.RetryAfter())
 		} else {
-			var apiError sdk.ApiError
-
-			if errors.As(err, &apiError) {
-				log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
-			}
-
-			log.Fatal(err)
+			log.Fatalf("Error: %s, %s", err.Code(), err.Error())
 		}
 	}
 
 	// Print full response as JSON
-	responseJsonData, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
+	responseJsonData, jsonErr := json.MarshalIndent(response, "", "  ")
+	if jsonErr != nil {
 		fmt.Println("Error:", err)
 		return
 	}

--- a/example/getRelatedVisitors.go
+++ b/example/getRelatedVisitors.go
@@ -44,7 +44,13 @@ func main() {
 		if errors.As(err, &tooManyRequestsError) {
 			log.Printf("Too many requests, retry after %d seconds", tooManyRequestsError.RetryAfter())
 		} else {
-			log.Print(err)
+			var apiError sdk.ApiError
+
+			if errors.As(err, &apiError) {
+				log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
+			}
+
+			log.Fatal(err)
 		}
 	}
 

--- a/example/getVisits.go
+++ b/example/getVisits.go
@@ -47,22 +47,16 @@ func main() {
 		if errors.As(err, &tooManyRequestsError) {
 			log.Printf("Too many requests, retry after %d seconds", tooManyRequestsError.RetryAfter())
 		} else {
-			var apiError sdk.ApiError
-
-			if errors.As(err, &apiError) {
-				log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
-			}
-
-			log.Fatal(err)
+			log.Fatalf("Error: %s, %s", err.Code(), err.Error())
 		}
 	}
 
 	fmt.Printf("Got response with visitorId: %s", response.VisitorId)
 
 	// Print full response as JSON
-	responseJsonData, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		fmt.Println("Error:", err)
+	responseJsonData, jsonErr := json.MarshalIndent(response, "", "  ")
+	if jsonErr != nil {
+		fmt.Println("Error:", jsonErr)
 		return
 	}
 	fmt.Println(string(responseJsonData))

--- a/example/getVisits.go
+++ b/example/getVisits.go
@@ -47,7 +47,13 @@ func main() {
 		if errors.As(err, &tooManyRequestsError) {
 			log.Printf("Too many requests, retry after %d seconds", tooManyRequestsError.RetryAfter())
 		} else {
-			log.Print(err)
+			var apiError sdk.ApiError
+
+			if errors.As(err, &apiError) {
+				log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
+			}
+
+			log.Fatal(err)
 		}
 	}
 

--- a/example/updateEvent.go
+++ b/example/updateEvent.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -46,6 +47,12 @@ func main() {
 	fmt.Printf("%+v\n", httpRes)
 
 	if err != nil {
+		var apiError sdk.ApiError
+
+		if errors.As(err, &apiError) {
+			log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
+		}
+
 		log.Fatal(err)
 	}
 }

--- a/example/updateEvent.go
+++ b/example/updateEvent.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -47,12 +46,6 @@ func main() {
 	fmt.Printf("%+v\n", httpRes)
 
 	if err != nil {
-		var apiError sdk.ApiError
-
-		if errors.As(err, &apiError) {
-			log.Fatalf("Error: %s, %s", apiError.Code(), apiError.Error())
-		}
-
-		log.Fatal(err)
+		log.Fatalf("Error: %s, %s", err.Code(), err.Error())
 	}
 }

--- a/sdk/api_error.go
+++ b/sdk/api_error.go
@@ -5,6 +5,7 @@ type ApiError struct {
 	body  []byte
 	error string
 	model any
+	code  ErrorCode
 }
 
 // Error returns non-empty string if there was an error.
@@ -20,4 +21,9 @@ func (e ApiError) Body() []byte {
 // Model returns the unpacked model of the error
 func (e ApiError) Model() any {
 	return e.model
+}
+
+// Code returns the error code
+func (e ApiError) Code() ErrorCode {
+	return e.code
 }

--- a/sdk/api_error.go
+++ b/sdk/api_error.go
@@ -1,5 +1,22 @@
 package sdk
 
+import "errors"
+
+// Error defines base interface of all errors returned by this SDK
+type Error interface {
+	error
+
+	// Body returns the raw bytes of the response, if available.
+	Body() []byte
+
+	// Code returns the error code.
+	Code() ErrorCode
+
+	// Model returns the unpacked model of the error. When error was created with WrapWithApiError, it returns the original error.
+	// If error was thrown after we get the HTTP Response, it contains model parsed from response body.
+	Model() any
+}
+
 // ApiError Provides access to the body, error and model on returned errors.
 type ApiError struct {
 	body  []byte
@@ -8,22 +25,36 @@ type ApiError struct {
 	code  ErrorCode
 }
 
+func WrapWithApiError(err error) *ApiError {
+	if err == nil {
+		return nil
+	}
+
+	var apiError *ApiError
+	if errors.As(err, &apiError) {
+		return apiError
+	}
+
+	return &ApiError{
+		error: err.Error(),
+		code:  FAILED,
+		model: err,
+	}
+}
+
 // Error returns non-empty string if there was an error.
 func (e ApiError) Error() string {
 	return e.error
 }
 
-// Body returns the raw bytes of the response
 func (e ApiError) Body() []byte {
 	return e.body
 }
 
-// Model returns the unpacked model of the error
 func (e ApiError) Model() any {
 	return e.model
 }
 
-// Code returns the error code
 func (e ApiError) Code() ErrorCode {
 	return e.code
 }

--- a/sdk/api_fingerprint.go
+++ b/sdk/api_fingerprint.go
@@ -25,7 +25,7 @@ type FingerprintApiServiceInterface interface {
 	    * @param visitorId The [visitor ID](https://dev.fingerprint.com/reference/get-function#visitorid) you want to delete.
 
 	*/
-	DeleteVisitorData(ctx context.Context, visitorId string) (*http.Response, error)
+	DeleteVisitorData(ctx context.Context, visitorId string) (*http.Response, Error)
 
 	/*
 	   FingerprintApiService Get event by request ID
@@ -34,7 +34,7 @@ type FingerprintApiServiceInterface interface {
 	    * @param requestId The unique [identifier](https://dev.fingerprint.com/reference/get-function#requestid) of each identification request.
 	       @return EventsGetResponse
 	*/
-	GetEvent(ctx context.Context, requestId string) (EventsGetResponse, *http.Response, error)
+	GetEvent(ctx context.Context, requestId string) (EventsGetResponse, *http.Response, Error)
 
 	/*
 	   FingerprintApiService Get Related Visitors
@@ -43,7 +43,7 @@ type FingerprintApiServiceInterface interface {
 	    * @param visitorId The [visitor ID](https://dev.fingerprint.com/reference/get-function#visitorid) for which you want to find the other visitor IDs that originated from the same mobile device.
 	       @return RelatedVisitorsResponse
 	*/
-	GetRelatedVisitors(ctx context.Context, visitorId string) (RelatedVisitorsResponse, *http.Response, error)
+	GetRelatedVisitors(ctx context.Context, visitorId string) (RelatedVisitorsResponse, *http.Response, Error)
 
 	/*
 	   FingerprintApiService Get visits by visitor ID
@@ -58,7 +58,7 @@ type FingerprintApiServiceInterface interface {
 	    * @param "Before" (int64) -  ⚠️ Deprecated pagination method, please use `paginationKey` instead. Timestamp (in milliseconds since epoch) used to paginate results.
 	   @return VisitorsGetResponse
 	*/
-	GetVisits(ctx context.Context, visitorId string, opts *FingerprintApiGetVisitsOpts) (VisitorsGetResponse, *http.Response, error)
+	GetVisits(ctx context.Context, visitorId string, opts *FingerprintApiGetVisitsOpts) (VisitorsGetResponse, *http.Response, Error)
 
 	/*
 	   FingerprintApiService Update an event with a given request ID
@@ -68,7 +68,7 @@ type FingerprintApiServiceInterface interface {
 	    * @param requestId The unique event [identifier](https://dev.fingerprint.com/reference/get-function#requestid).
 
 	*/
-	UpdateEvent(ctx context.Context, body EventsUpdateRequest, requestId string) (*http.Response, error)
+	UpdateEvent(ctx context.Context, body EventsUpdateRequest, requestId string) (*http.Response, Error)
 }
 
 type requestDefinition struct {

--- a/sdk/api_fingerprint_impl.go
+++ b/sdk/api_fingerprint_impl.go
@@ -151,7 +151,7 @@ func (f *FingerprintApiService) doRequest(ctx context.Context, apiRequest apiReq
 		return httpResponse, err
 	}
 
-	_, err = handleErrorResponse(body, httpResponse, apiRequest.definition)
+	err = handleErrorResponse(body, httpResponse, apiRequest.definition)
 
 	return httpResponse, handlePotentialTooManyRequestsResponse(httpResponse, err)
 }

--- a/sdk/request_utils.go
+++ b/sdk/request_utils.go
@@ -67,14 +67,11 @@ func addIntegrationInfoToQuery(query *url.Values) {
 	query.Add("ii", IntegrationInfo)
 }
 
-// UNKNOWN_ERROR_CODE is a fallback error code for unknown errors, usually used when ErrorPlainResponse is returned
-var UNKNOWN_ERROR_CODE ErrorCode = "UNKNOWN"
-
 func handleErrorResponse(body []byte, httpResponse *http.Response, definition requestDefinition) (*http.Response, error) {
 	apiError := ApiError{
 		body:  body,
 		error: httpResponse.Status,
-		code:  UNKNOWN_ERROR_CODE,
+		code:  FAILED,
 	}
 
 	modelFactory := definition.StatusCodeResultsFactoryMap[httpResponse.StatusCode]

--- a/sdk/request_utils.go
+++ b/sdk/request_utils.go
@@ -67,7 +67,7 @@ func addIntegrationInfoToQuery(query *url.Values) {
 	query.Add("ii", IntegrationInfo)
 }
 
-func handleErrorResponse(body []byte, httpResponse *http.Response, definition requestDefinition) (*http.Response, error) {
+func handleErrorResponse(body []byte, httpResponse *http.Response, definition requestDefinition) error {
 	apiError := ApiError{
 		body:  body,
 		error: httpResponse.Status,
@@ -84,7 +84,7 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 		if err != nil {
 			apiError.error = err.Error()
 
-			return httpResponse, apiError
+			return apiError
 		}
 
 		switch v := model.(type) {
@@ -99,7 +99,7 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 		apiError.model = model
 	}
 
-	return httpResponse, apiError
+	return apiError
 }
 
 func isResponseOk(httpResponse *http.Response) bool {

--- a/sdk/request_utils.go
+++ b/sdk/request_utils.go
@@ -9,15 +9,15 @@ import (
 	"strconv"
 )
 
-func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err error) error {
+func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err Error) Error {
 	if err == nil {
-		return err
+		return nil
 	}
 
-	var e ApiError
+	var e *ApiError
 
 	if httpResponse.StatusCode != http.StatusTooManyRequests {
-		return err
+		return WrapWithApiError(err)
 	}
 
 	if errors.As(err, &e) {
@@ -67,7 +67,7 @@ func addIntegrationInfoToQuery(query *url.Values) {
 	query.Add("ii", IntegrationInfo)
 }
 
-func handleErrorResponse(body []byte, httpResponse *http.Response, definition requestDefinition) error {
+func handleErrorResponse(body []byte, httpResponse *http.Response, definition requestDefinition) *ApiError {
 	apiError := ApiError{
 		body:  body,
 		error: httpResponse.Status,
@@ -84,7 +84,7 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 		if err != nil {
 			apiError.error = err.Error()
 
-			return apiError
+			return &apiError
 		}
 
 		switch v := model.(type) {
@@ -99,7 +99,7 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 		apiError.model = model
 	}
 
-	return apiError
+	return &apiError
 }
 
 func isResponseOk(httpResponse *http.Response) bool {

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -84,6 +84,8 @@ func main() {
 		if errors.As(err, &tooManyRequestsError) {
 			log.Fatalf("Too many requests, retry after %d seconds", tooManyRequestsError.RetryAfter())
 		} else {
+			// You can also use err.Model() and err.Body() to get more details about the error
+			log.Printf("Error %s: %v", err.Code(), err)
 			log.Fatal(err)
 		}
 	}
@@ -92,12 +94,13 @@ func main() {
 
 	event, httpRes, err := client.FingerprintApi.GetEvent(auth, requestId)
 	if err != nil {
+		// You can also use err.Model() and err.Body() to get more details about the error
+		log.Printf("Error %s: %v", err.Code(), err)
 		log.Fatal(err)
-    }
+        }
 
 	if event.Products.Identification != nil {
 		fmt.Printf("Got response with Identification: %v", event.Products.Identification)
-
 	}
 }
 ```

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -23,7 +23,7 @@ type {{classname}}ServiceInterface interface {
     {{/required}}{{/allParams}}{{/hasOptionalParams}}
     {{#returnType}}@return {{{returnType}}}{{/returnType}}
     */
-    {{{nickname}}}(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}opts *{{{classname}}}{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}*http.Response, error)
+    {{{nickname}}}(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}opts *{{{classname}}}{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}*http.Response, Error)
 
 {{/operation}}
 }

--- a/test/DeleteVisitorData_test.go
+++ b/test/DeleteVisitorData_test.go
@@ -44,7 +44,7 @@ func TestDeleteVisitorData(t *testing.T) {
 
 		res, err := client.FingerprintApi.DeleteVisitorData(ctx, "123")
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 200)
 	})
@@ -91,7 +91,7 @@ func TestDeleteVisitorData(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 404)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})
@@ -190,7 +190,7 @@ func TestDeleteVisitorData(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 400)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})
@@ -237,7 +237,7 @@ func TestDeleteVisitorData(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 403)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})

--- a/test/GetEvent_test.go
+++ b/test/GetEvent_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7/config"
 	"github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7/sdk"
@@ -51,7 +50,7 @@ func TestGetEvent(t *testing.T) {
 
 		res, _, err := client.FingerprintApi.GetEvent(ctx, "123")
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res, mockResponse)
 
@@ -93,7 +92,7 @@ func TestGetEvent(t *testing.T) {
 
 		res, _, err := client.FingerprintApi.GetEvent(ctx, "123")
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res, mockResponse)
 
@@ -135,7 +134,7 @@ func TestGetEvent(t *testing.T) {
 
 		res, _, err := client.FingerprintApi.GetEvent(ctx, "123")
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res, mockResponse)
 	})
@@ -180,17 +179,14 @@ func TestGetEvent(t *testing.T) {
 		res, _, err := client.FingerprintApi.GetEvent(ctx, "123")
 
 		assert.Error(t, err)
-		assert.IsType(t, err, sdk.ApiError{})
+		assert.IsType(t, err, &sdk.ApiError{})
 		assert.NotNil(t, res)
 
-		var apiError sdk.ApiError
-		errors.As(err, &apiError)
-
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
-		assert.Equal(t, apiError.Code(), *mockResponse.Error_.Code)
-		assert.Equal(t, apiError.Error(), mockResponse.Error_.Message)
+		assert.Equal(t, err.Code(), *mockResponse.Error_.Code)
+		assert.Equal(t, err.Error(), mockResponse.Error_.Message)
 	})
 
 	t.Run("Return too many requests error in all fields", func(t *testing.T) {
@@ -229,7 +225,7 @@ func TestGetEvent(t *testing.T) {
 
 		res, _, err := client.FingerprintApi.GetEvent(ctx, "123")
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res, mockResponse)
 	})
@@ -270,7 +266,7 @@ func TestGetEvent(t *testing.T) {
 
 		res, _, err := client.FingerprintApi.GetEvent(ctx, "123")
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res, mockResponse)
 		assert.Equal(t, *res.Products.Botd.Error_.Code, sdk.FAILED)
@@ -313,7 +309,7 @@ func TestGetEvent(t *testing.T) {
 
 		res, _, err := client.FingerprintApi.GetEvent(ctx, "123")
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res, mockResponse)
 		assert.Equal(t, *res.Products.Identification.Error_.Code, sdk.FAILED)
@@ -405,7 +401,7 @@ func TestGetEvent(t *testing.T) {
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			parseErr := r.ParseForm()
-			assert.NoError(t, parseErr)
+			assert.Nil(t, parseErr)
 
 			apiKey := r.Header.Get("Auth-Api-Key")
 			assert.Equal(t, apiKey, "api_key")
@@ -514,7 +510,7 @@ func TestGetEvent(t *testing.T) {
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			parseErr := r.ParseForm()
-			assert.NoError(t, parseErr)
+			assert.Nil(t, parseErr)
 
 			apiKey := r.Header.Get("Auth-Api-Key")
 			assert.Equal(t, apiKey, "api_key")
@@ -535,7 +531,7 @@ func TestGetEvent(t *testing.T) {
 		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "api_key"})
 
 		res, _, err := client.FingerprintApi.GetEvent(ctx, "request_id")
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res.Products.Botd.Data.Url, "https://www.example.com/{{{login")
 	})

--- a/test/GetEvent_test.go
+++ b/test/GetEvent_test.go
@@ -189,7 +189,8 @@ func TestGetEvent(t *testing.T) {
 		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
 
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
-
+		assert.Equal(t, apiError.Code(), *mockResponse.Error_.Code)
+		assert.Equal(t, apiError.Error(), mockResponse.Error_.Message)
 	})
 
 	t.Run("Return too many requests error in all fields", func(t *testing.T) {

--- a/test/GetRelatedVisitors_test.go
+++ b/test/GetRelatedVisitors_test.go
@@ -42,7 +42,7 @@ func TestGetRelatedVisitors(t *testing.T) {
 		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "api_key"})
 
 		res, _, err := client.FingerprintApi.GetRelatedVisitors(ctx, mockResponse.RelatedVisitors[0].VisitorId)
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res, mockResponse)
 	})
@@ -52,7 +52,7 @@ func TestGetRelatedVisitors(t *testing.T) {
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			parseErr := r.ParseForm()
-			assert.NoError(t, parseErr)
+			assert.Nil(t, parseErr)
 
 			configFile := config.ReadConfig("../config.json")
 
@@ -132,7 +132,7 @@ func TestGetRelatedVisitors(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, 400, res.StatusCode)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})
@@ -179,7 +179,7 @@ func TestGetRelatedVisitors(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, 403, res.StatusCode)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})
@@ -226,7 +226,7 @@ func TestGetRelatedVisitors(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, 404, res.StatusCode)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})

--- a/test/GetVisits_test.go
+++ b/test/GetVisits_test.go
@@ -210,7 +210,7 @@ func TestGetVisits(t *testing.T) {
 
 		errorModel := apiError.Model().(*sdk.ErrorPlainResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorPlainResponse{})
-		assert.Equal(t, apiError.Code(), sdk.UNKNOWN_ERROR_CODE)
+		assert.Equal(t, apiError.Code(), sdk.FAILED)
 		assert.Equal(t, apiError.Error(), mockResponse.Error_)
 	})
 

--- a/test/GetVisits_test.go
+++ b/test/GetVisits_test.go
@@ -40,7 +40,7 @@ func TestGetVisits(t *testing.T) {
 		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "api_key"})
 
 		res, _, err := client.FingerprintApi.GetVisits(ctx, "visitor_id", nil)
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res.VisitorId, mockResponse.VisitorId)
 	})
@@ -57,7 +57,7 @@ func TestGetVisits(t *testing.T) {
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			parseErr := r.ParseForm()
-			assert.NoError(t, parseErr)
+			assert.Nil(t, parseErr)
 
 			assert.Equal(t, r.Form.Get("request_id"), opts.RequestId)
 			assert.Equal(t, r.Form.Get("paginationKey"), fmt.Sprint(opts.PaginationKey))
@@ -81,7 +81,7 @@ func TestGetVisits(t *testing.T) {
 		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "api_key"})
 
 		res, _, err := client.FingerprintApi.GetVisits(ctx, "visitor_id", &opts)
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res.VisitorId, mockResponse.VisitorId)
 		assert.Equal(t, res.Visits, mockResponse.Visits)
@@ -101,7 +101,7 @@ func TestGetVisits(t *testing.T) {
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			parseErr := r.ParseForm()
-			assert.NoError(t, parseErr)
+			assert.Nil(t, parseErr)
 
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", "10")
@@ -143,7 +143,7 @@ func TestGetVisits(t *testing.T) {
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			parseErr := r.ParseForm()
-			assert.NoError(t, parseErr)
+			assert.Nil(t, parseErr)
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusTooManyRequests)
@@ -184,7 +184,7 @@ func TestGetVisits(t *testing.T) {
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			parseErr := r.ParseForm()
-			assert.NoError(t, parseErr)
+			assert.Nil(t, parseErr)
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
@@ -201,17 +201,14 @@ func TestGetVisits(t *testing.T) {
 		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "api_key"})
 
 		res, _, err := client.FingerprintApi.GetVisits(ctx, "visitor_id", &opts)
-		assert.IsType(t, err, sdk.ApiError{})
+		assert.IsType(t, err, &sdk.ApiError{})
 		assert.Error(t, err)
 		assert.NotNil(t, res)
 
-		var apiError sdk.ApiError
-		errors.As(err, &apiError)
-
-		errorModel := apiError.Model().(*sdk.ErrorPlainResponse)
+		errorModel := err.Model().(*sdk.ErrorPlainResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorPlainResponse{})
-		assert.Equal(t, apiError.Code(), sdk.FAILED)
-		assert.Equal(t, apiError.Error(), mockResponse.Error_)
+		assert.Equal(t, err.Code(), sdk.FAILED)
+		assert.Equal(t, err.Error(), mockResponse.Error_)
 	})
 
 }

--- a/test/Unseal_test.go
+++ b/test/Unseal_test.go
@@ -46,7 +46,7 @@ func TestUnsealEventsResponse(t *testing.T) {
 		}
 		unsealed, err := sealed.UnsealEventsResponse(sealedResult, keys)
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 
 		isEqual := reflect.DeepEqual(*unsealed, expectedResponse)
 

--- a/test/UpdateEvent_test.go
+++ b/test/UpdateEvent_test.go
@@ -47,7 +47,7 @@ func TestUpdateEvent(t *testing.T) {
 			Suspect:  true,
 		}, "123")
 
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 200)
 	})
@@ -98,7 +98,7 @@ func TestUpdateEvent(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 404)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})
@@ -149,7 +149,7 @@ func TestUpdateEvent(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 400)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})
@@ -200,7 +200,7 @@ func TestUpdateEvent(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 403)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})
@@ -251,7 +251,7 @@ func TestUpdateEvent(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.StatusCode, 409)
 
-		errorModel := err.(sdk.ApiError).Model().(*sdk.ErrorResponse)
+		errorModel := err.(*sdk.ApiError).Model().(*sdk.ErrorResponse)
 		assert.IsType(t, errorModel, &sdk.ErrorResponse{})
 		assert.Equal(t, errorModel, &mockResponse)
 	})

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -14,7 +14,7 @@ func TestWebhookModel(t *testing.T) {
 	t.Run("Check if webhook response can be unmarshalled", func(t *testing.T) {
 		var mockResponse sdk.Webhook
 		err := readFromFileAndUnmarshalWithError("../test/mocks/webhook.json", &mockResponse)
-		assert.NoError(t, err)
+		assert.Nil(t, err)
 	})
 }
 


### PR DESCRIPTION
- Expose ErrorCode in `ApiError.Code()` for easier access
- Replace `ApiError.Error()` with actual errors message if available, rather than using status code text