### PR TITLE
fix: don't send `null` Tag in `UpdateEvent` operation

### DIFF
--- a/.changeset/warm-buttons-speak.md
+++ b/.changeset/warm-buttons-speak.md
@@ -1,0 +1,5 @@
+---
+"fingerprint-pro-server-api-go-sdk": patch
+---
+
+Don't send `null` Tag in `UpdateEvent` operation

--- a/sdk/api_fingerprint_impl.go
+++ b/sdk/api_fingerprint_impl.go
@@ -48,6 +48,12 @@ func (f *FingerprintApiService) GetEvent(ctx context.Context, requestId string) 
 }
 
 func (f *FingerprintApiService) UpdateEvent(ctx context.Context, body EventsUpdateRequest, requestId string) (*http.Response, Error) {
+	// Avoid passing empty tag, which would result in serialisation to `null`, since our API doesn't support that
+	// TODO In the next major release, make `Tag` just a `ModelMap` so that `omitempty` can apply here.
+	if body.Tag != nil && len(*body.Tag) == 0 {
+		body.Tag = nil
+	}
+
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, WrapWithApiError(err)

--- a/test/UpdateEvent_test.go
+++ b/test/UpdateEvent_test.go
@@ -95,6 +95,50 @@ func TestUpdateEvent(t *testing.T) {
 		assert.Equal(t, res.StatusCode, 200)
 	})
 
+	t.Run("Update with empty tag", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(
+			w http.ResponseWriter,
+			r *http.Request,
+		) {
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "{}", string(body))
+
+			configFile := config.ReadConfig("../config.json")
+			integrationInfo := r.URL.Query().Get("ii")
+			assert.Equal(t, integrationInfo, fmt.Sprintf("fingerprint-pro-server-go-sdk/%s", configFile.PackageVersion))
+			assert.Equal(t, r.URL.Path, "/events/123")
+			assert.Equal(t, r.Method, http.MethodPut)
+
+			apiKey := r.Header.Get("Auth-Api-Key")
+			assert.Equal(t, apiKey, "api_key")
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+		}))
+		defer ts.Close()
+
+		cfg := sdk.NewConfiguration()
+		cfg.ChangeBasePath(ts.URL)
+
+		client := sdk.NewAPIClient(cfg)
+
+		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{
+			Key: "api_key",
+		})
+
+		var tag sdk.ModelMap
+
+		res, err := client.FingerprintApi.UpdateEvent(ctx, sdk.EventsUpdateRequest{
+			Tag: &tag,
+		}, "123")
+
+		assert.Nil(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, res.StatusCode, 200)
+	})
+
 	t.Run("Update with just suspect=false", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(
 			w http.ResponseWriter,

--- a/test/UpdateEvent_test.go
+++ b/test/UpdateEvent_test.go
@@ -139,6 +139,50 @@ func TestUpdateEvent(t *testing.T) {
 		assert.Equal(t, res.StatusCode, 200)
 	})
 
+	t.Run("Update with empty tag struct", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(
+			w http.ResponseWriter,
+			r *http.Request,
+		) {
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "{}", string(body))
+
+			configFile := config.ReadConfig("../config.json")
+			integrationInfo := r.URL.Query().Get("ii")
+			assert.Equal(t, integrationInfo, fmt.Sprintf("fingerprint-pro-server-go-sdk/%s", configFile.PackageVersion))
+			assert.Equal(t, r.URL.Path, "/events/123")
+			assert.Equal(t, r.Method, http.MethodPut)
+
+			apiKey := r.Header.Get("Auth-Api-Key")
+			assert.Equal(t, apiKey, "api_key")
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+		}))
+		defer ts.Close()
+
+		cfg := sdk.NewConfiguration()
+		cfg.ChangeBasePath(ts.URL)
+
+		client := sdk.NewAPIClient(cfg)
+
+		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{
+			Key: "api_key",
+		})
+
+		tag := sdk.ModelMap{}
+
+		res, err := client.FingerprintApi.UpdateEvent(ctx, sdk.EventsUpdateRequest{
+			Tag: &tag,
+		}, "123")
+
+		assert.Nil(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, res.StatusCode, 200)
+	})
+
 	t.Run("Update with just suspect=false", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(
 			w http.ResponseWriter,


### PR DESCRIPTION
This PR applies fix to `UpdateEvent` operation to ensure that `null` `Tag` won't be sent to our API.