### PR TITLE
ci: set Datadog team in functional_tests workflow runs

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -9,6 +9,12 @@ on:
     - cron: "0 5 * * *"
 
 jobs:
+  set_datadog_team:
+    name: 'Set Datadog team'
+    uses: fingerprintjs/dx-team-toolkit/.github/workflows/set-datadog-team.yml@v1
+    secrets:
+      DD_API_KEY: ${{ secrets.INTEGRATIONS_DATADOG_API_KEY }}
+
   tests:
     name: Functional tests (GO ${{ matrix.go-version }})
     runs-on: "ubuntu-latest"
@@ -28,14 +34,3 @@ jobs:
         working-directory: functional_test
         env:
           FINGERPRINT_API_KEY: ${{ secrets.FINGERPRINT_API_KEY }}
-
-  report-status:
-    needs: tests
-    if: always()
-    uses: fingerprintjs/dx-team-toolkit/.github/workflows/report-workflow-status.yml@v1
-    with:
-      notification_title: 'GO SDK Tests has {status_message}'
-      job_status: ${{ needs.tests.result }}
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-


### PR DESCRIPTION
- Adds a new job to the functional_tests workflow to set the Datadog team using the set-datadog-team workflow from dx-team-toolkit. This will associate workflow results with the integrations team in Datadog.
- Removes the report_status job in favor of centralizing notifications with Datadog monitors.