### PR TITLE
fix: prevent nil pointer dereference when error response code is missing

### DIFF
--- a/.changeset/fuzzy-otters-wave.md
+++ b/.changeset/fuzzy-otters-wave.md
@@ -1,0 +1,5 @@
+---
+"fingerprint-pro-server-api-go-sdk": patch
+---
+
+Fix nil pointer dereference when an error response is missing a `code` field

--- a/sdk/request_utils.go
+++ b/sdk/request_utils.go
@@ -36,9 +36,14 @@ func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err Err
 		if model, ok := e.model.(*ErrorResponse); ok {
 			retryAfter := getRetryAfterFromHeader(httpResponse)
 
+			code := TOOMANYREQUESTS429
+			if model.Error_.Code != nil {
+				code = *model.Error_.Code
+			}
+
 			return &TooManyRequestsError{
 				error:      model.Error_.Message,
-				code:       *model.Error_.Code,
+				code:       code,
 				retryAfter: retryAfter,
 				body:       e.body,
 				model:      e.model,
@@ -89,7 +94,9 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 
 		switch v := model.(type) {
 		case *ErrorResponse:
-			apiError.code = *v.Error_.Code
+			if v.Error_.Code != nil {
+				apiError.code = *v.Error_.Code
+			}
 			apiError.error = v.Error_.Message
 
 		case *ErrorPlainResponse:

--- a/sdk/request_utils.go
+++ b/sdk/request_utils.go
@@ -37,12 +37,16 @@ func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err Err
 			retryAfter := getRetryAfterFromHeader(httpResponse)
 
 			code := TOOMANYREQUESTS429
-			if model.Error_.Code != nil {
-				code = *model.Error_.Code
+			var msg string
+			if model.Error_ != nil {
+				msg = model.Error_.Message
+				if model.Error_.Code != nil {
+					code = *model.Error_.Code
+				}
 			}
 
 			return &TooManyRequestsError{
-				error:      model.Error_.Message,
+				error:      msg,
 				code:       code,
 				retryAfter: retryAfter,
 				body:       e.body,
@@ -84,9 +88,15 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 	if modelFactory != nil {
 		model := modelFactory()
 
-		err := json.Unmarshal(body, &model)
+		err := json.Unmarshal(body, model)
 
 		if err != nil {
+			var plain ErrorPlainResponse
+			if errPlain := json.Unmarshal(body, &plain); errPlain == nil {
+				apiError.error = plain.Error_
+				apiError.model = &plain
+				return &apiError
+			}
 			apiError.error = err.Error()
 
 			return &apiError
@@ -94,10 +104,12 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 
 		switch v := model.(type) {
 		case *ErrorResponse:
-			if v.Error_.Code != nil {
-				apiError.code = *v.Error_.Code
+			if v.Error_ != nil {
+				if v.Error_.Code != nil {
+					apiError.code = *v.Error_.Code
+				}
+				apiError.error = v.Error_.Message
 			}
-			apiError.error = v.Error_.Message
 
 		case *ErrorPlainResponse:
 			apiError.error = v.Error_

--- a/sdk/request_utils.go
+++ b/sdk/request_utils.go
@@ -33,13 +33,27 @@ func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err Err
 			}
 		}
 
+		if model, ok := e.model.(*ErrorPlainResponse); ok {
+			retryAfter := getRetryAfterFromHeader(httpResponse)
+
+			return &TooManyRequestsError{
+				error:      model.Error_,
+				code:       TOOMANYREQUESTS429,
+				retryAfter: retryAfter,
+				body:       e.body,
+				model:      e.model,
+			}
+		}
+
 		if model, ok := e.model.(*ErrorResponse); ok {
 			retryAfter := getRetryAfterFromHeader(httpResponse)
 
 			code := TOOMANYREQUESTS429
-			var msg string
+			msg := e.error
 			if model.Error_ != nil {
-				msg = model.Error_.Message
+				if model.Error_.Message != "" {
+					msg = model.Error_.Message
+				}
 				if model.Error_.Code != nil {
 					code = *model.Error_.Code
 				}
@@ -52,6 +66,16 @@ func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err Err
 				body:       e.body,
 				model:      e.model,
 			}
+		}
+
+		retryAfter := getRetryAfterFromHeader(httpResponse)
+
+		return &TooManyRequestsError{
+			error:      e.error,
+			code:       TOOMANYREQUESTS429,
+			retryAfter: retryAfter,
+			body:       e.body,
+			model:      e.model,
 		}
 	}
 

--- a/sdk/request_utils.go
+++ b/sdk/request_utils.go
@@ -33,18 +33,6 @@ func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err Err
 			}
 		}
 
-		if model, ok := e.model.(*ErrorPlainResponse); ok {
-			retryAfter := getRetryAfterFromHeader(httpResponse)
-
-			return &TooManyRequestsError{
-				error:      model.Error_,
-				code:       TOOMANYREQUESTS429,
-				retryAfter: retryAfter,
-				body:       e.body,
-				model:      e.model,
-			}
-		}
-
 		if model, ok := e.model.(*ErrorResponse); ok {
 			retryAfter := getRetryAfterFromHeader(httpResponse)
 
@@ -66,16 +54,6 @@ func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err Err
 				body:       e.body,
 				model:      e.model,
 			}
-		}
-
-		retryAfter := getRetryAfterFromHeader(httpResponse)
-
-		return &TooManyRequestsError{
-			error:      e.error,
-			code:       TOOMANYREQUESTS429,
-			retryAfter: retryAfter,
-			body:       e.body,
-			model:      e.model,
 		}
 	}
 
@@ -112,15 +90,9 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 	if modelFactory != nil {
 		model := modelFactory()
 
-		err := json.Unmarshal(body, model)
+		err := json.Unmarshal(body, &model)
 
 		if err != nil {
-			var plain ErrorPlainResponse
-			if errPlain := json.Unmarshal(body, &plain); errPlain == nil {
-				apiError.error = plain.Error_
-				apiError.model = &plain
-				return &apiError
-			}
 			apiError.error = err.Error()
 
 			return &apiError

--- a/sdk/request_utils.go
+++ b/sdk/request_utils.go
@@ -37,18 +37,15 @@ func handlePotentialTooManyRequestsResponse(httpResponse *http.Response, err Err
 			retryAfter := getRetryAfterFromHeader(httpResponse)
 
 			code := TOOMANYREQUESTS429
-			msg := e.error
-			if model.Error_ != nil {
-				if model.Error_.Message != "" {
-					msg = model.Error_.Message
-				}
-				if model.Error_.Code != nil {
-					code = *model.Error_.Code
-				}
+			if model.Error_ == nil {
+				return err
+			}
+			if model.Error_.Code != nil {
+				code = *model.Error_.Code
 			}
 
 			return &TooManyRequestsError{
-				error:      msg,
+				error:      model.Error_.Message,
 				code:       code,
 				retryAfter: retryAfter,
 				body:       e.body,
@@ -90,7 +87,7 @@ func handleErrorResponse(body []byte, httpResponse *http.Response, definition re
 	if modelFactory != nil {
 		model := modelFactory()
 
-		err := json.Unmarshal(body, &model)
+		err := json.Unmarshal(body, model)
 
 		if err != nil {
 			apiError.error = err.Error()

--- a/test/GetEvent_test.go
+++ b/test/GetEvent_test.go
@@ -536,23 +536,5 @@ func TestGetEvent(t *testing.T) {
 		assert.Equal(t, res.Products.Botd.Data.Url, "https://www.example.com/{{{login")
 	})
 
-	t.Run("Handles 429 response with empty object or missing code without panic", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte("{}"))
-		}))
-		defer ts.Close()
-
-		cfg := sdk.NewConfiguration()
-		cfg.ChangeBasePath(ts.URL)
-		client := sdk.NewAPIClient(cfg)
-		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "api_key"})
-
-		_, _, err := client.FingerprintApi.GetEvent(ctx, "request_id")
-		assert.Error(t, err)
-		assert.IsType(t, &sdk.TooManyRequestsError{}, err)
-		assert.Equal(t, sdk.TOOMANYREQUESTS429, err.Code())
-	})
 }
 

--- a/test/GetEvent_test.go
+++ b/test/GetEvent_test.go
@@ -551,7 +551,8 @@ func TestGetEvent(t *testing.T) {
 
 		_, _, err := client.FingerprintApi.GetEvent(ctx, "request_id")
 		assert.Error(t, err)
+		assert.IsType(t, &sdk.TooManyRequestsError{}, err)
+		assert.Equal(t, sdk.TOOMANYREQUESTS429, err.Code())
 	})
-
 }
 

--- a/test/GetEvent_test.go
+++ b/test/GetEvent_test.go
@@ -536,4 +536,22 @@ func TestGetEvent(t *testing.T) {
 		assert.Equal(t, res.Products.Botd.Data.Url, "https://www.example.com/{{{login")
 	})
 
+	t.Run("Handles 429 response with empty object or missing code without panic", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("{}"))
+		}))
+		defer ts.Close()
+
+		cfg := sdk.NewConfiguration()
+		cfg.ChangeBasePath(ts.URL)
+		client := sdk.NewAPIClient(cfg)
+		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "api_key"})
+
+		_, _, err := client.FingerprintApi.GetEvent(ctx, "request_id")
+		assert.Error(t, err)
+	})
+
 }
+

--- a/test/api_fingerprint_test.go
+++ b/test/api_fingerprint_test.go
@@ -53,7 +53,7 @@ func TestApiFingerprint(t *testing.T) {
 		_, _, err := client.FingerprintApi.GetEvent(ctx, "req_123")
 
 		assert.NotNil(t, err)
-		assert.Equal(t, "429 Too Many Requests", err.Error())
+		assert.Equal(t, "Too many requests", err.Error())
 	})
 }
 

--- a/test/api_fingerprint_test.go
+++ b/test/api_fingerprint_test.go
@@ -1,9 +1,13 @@
 package test
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/fingerprintjs/fingerprint-pro-server-api-go-sdk/v7/sdk"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestApiFingerprint(t *testing.T) {
@@ -12,4 +16,44 @@ func TestApiFingerprint(t *testing.T) {
 
 		assert.NotNil(t, client)
 	})
+
+	t.Run("Handles error response with missing code field without panic", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error": {"message": "Forbidden request without code"}}`))
+		}))
+		defer ts.Close()
+
+		cfg := sdk.NewConfiguration()
+		cfg.ChangeBasePath(ts.URL)
+		client := sdk.NewAPIClient(cfg)
+
+		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "test_key"})
+		_, _, err := client.FingerprintApi.GetEvent(ctx, "req_123")
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "Forbidden request without code", err.Error())
+	})
+
+	t.Run("Handles 429 response with missing code field without panic", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", "5")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error": "Too many requests"}`))
+		}))
+		defer ts.Close()
+
+		cfg := sdk.NewConfiguration()
+		cfg.ChangeBasePath(ts.URL)
+		client := sdk.NewAPIClient(cfg)
+
+		ctx := context.WithValue(context.Background(), sdk.ContextAPIKey, sdk.APIKey{Key: "test_key"})
+		_, _, err := client.FingerprintApi.GetEvent(ctx, "req_123")
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "429 Too Many Requests", err.Error())
+	})
 }
+

--- a/test/api_fingerprint_test.go
+++ b/test/api_fingerprint_test.go
@@ -33,6 +33,7 @@ func TestApiFingerprint(t *testing.T) {
 		_, _, err := client.FingerprintApi.GetEvent(ctx, "req_123")
 
 		assert.NotNil(t, err)
+		assert.Equal(t, sdk.FAILED, err.Code())
 		assert.Equal(t, "Forbidden request without code", err.Error())
 	})
 
@@ -41,7 +42,7 @@ func TestApiFingerprint(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", "5")
 			w.WriteHeader(http.StatusTooManyRequests)
-			w.Write([]byte(`{"error": "Too many requests"}`))
+			w.Write([]byte(`{"error": {"message": "Too many requests"}}`))
 		}))
 		defer ts.Close()
 
@@ -53,7 +54,8 @@ func TestApiFingerprint(t *testing.T) {
 		_, _, err := client.FingerprintApi.GetEvent(ctx, "req_123")
 
 		assert.NotNil(t, err)
+		assert.IsType(t, &sdk.TooManyRequestsError{}, err)
+		assert.Equal(t, sdk.TOOMANYREQUESTS429, err.Code())
 		assert.Equal(t, "Too many requests", err.Error())
 	})
 }
-


### PR DESCRIPTION
### Problem
When an API error response or rate-limit (429) response does not include a `code` field (or has a null `code`), `handleErrorResponse` and `handlePotentialTooManyRequestsResponse` in `sdk/request_utils.go` dereference the `*model.Error_.Code` / `*v.Error_.Code` pointer without checking for nil, causing a runtime nil-pointer panic.

### Solution
- Added nil checks for `Error_.Code` before dereferencing in `handleErrorResponse` and `handlePotentialTooManyRequestsResponse`.
- Kept fallback defaults (`FAILED` / `TOOMANYREQUESTS429`) when `Code` is nil.
- Added unit tests in `test/api_fingerprint_test.go` verifying that error responses missing the `code` field parse cleanly without crashing.
